### PR TITLE
fix: resolve security vulnerabilities in API and frontend app

### DIFF
--- a/api/src/express.bootstrap.js
+++ b/api/src/express.bootstrap.js
@@ -31,7 +31,8 @@ export default (port, mongooseConnection) => {
     app.use(jsonApiSendOverride());
 
     app.use(bodyParser.json({
-      type: 'application/vnd.api+json'
+      type: 'application/vnd.api+json',
+      limit: '100kb'
     }));
 
     app.use('/api/movies', configureMoviesRoutes(moviesRepository));

--- a/api/src/json-api/resource.deserializer.js
+++ b/api/src/json-api/resource.deserializer.js
@@ -1,5 +1,25 @@
 'use strict';
 
+const VALIDATORS = {
+  title (value) {
+    if (typeof value !== 'string') throw new Error('The "title" attribute must be a string.');
+    if (value.length > 500) throw new Error('The "title" attribute must be 500 characters or fewer.');
+  },
+  releaseYear (value) {
+    if (typeof value !== 'number' || !Number.isInteger(value)) throw new Error('The "releaseYear" attribute must be an integer.');
+    if (value < 1888 || value > 2200) throw new Error('The "releaseYear" attribute must be a valid year (1888–2200).');
+  },
+  rating (value) {
+    if (typeof value !== 'number') throw new Error('The "rating" attribute must be a number.');
+    if (value < 0 || value > 10) throw new Error('The "rating" attribute must be between 0 and 10.');
+  },
+  imageUrl (value) {
+    if (typeof value !== 'string') throw new Error('The "imageUrl" attribute must be a string.');
+    if (value.length > 2048) throw new Error('The "imageUrl" attribute must be 2048 characters or fewer.');
+    if (!/^https?:\/\//i.test(value)) throw new Error('The "imageUrl" attribute must be an http or https URL.');
+  }
+};
+
 export default function (type, attributes, resource) {
   const model = {};
 
@@ -19,9 +39,14 @@ export default function (type, attributes, resource) {
     throw new Error('Must specify the "attributes" property of the resource as an object.');
   }
 
-  model.id = resource.id;
   for (let key of attributes) {
-    model[key] = resource.attributes[key] ? resource.attributes[key] : null;
+    const value = resource.attributes[key];
+    if (value != null && VALIDATORS[key]) {
+      VALIDATORS[key](value);
+    }
+    model[key] = value != null ? value : null;
   }
+
+  model.id = resource.id;
   return model;
 };

--- a/api/src/movies/movies.repository.js
+++ b/api/src/movies/movies.repository.js
@@ -35,7 +35,7 @@ class MoviesRepository {
   }
 
   delete(id) {
-    return this.Movie.findByIdAndRemove(id).exec();
+    return this.Movie.findByIdAndDelete(id).exec();
   }
 }
 

--- a/api/src/movies/movies.router.js
+++ b/api/src/movies/movies.router.js
@@ -13,16 +13,17 @@ export default function (moviesRepository) {
     .patch('/:id', update)
     .delete('/:id', remove);
 
-  function findAll (req, res) {
+  function findAll (req, res, next) {
     moviesRepository.findAll()
       .then((movies) => {
         res.json({
           data: movies.map(serializeMovie)
         });
-      });
+      })
+      .catch(next);
   }
 
-  function findOne (req, res) {
+  function findOne (req, res, next) {
     moviesRepository.findOne(req.params.id)
       .then((movie) => {
         if (!movie) {
@@ -32,16 +33,18 @@ export default function (moviesRepository) {
         res.json({
           data: serializeMovie(movie)
         });
-      });
+      })
+      .catch(next);
   }
 
-  function create (req, res) {
+  function create (req, res, next) {
     let model;
 
     try {
       model = deserializeMovieRequest(req);
       if (model.id) {
         res.status(403).sendError(new Error('May not specify an "id" property value to use.'));
+        return;
       }
     }
     catch (err) {
@@ -53,16 +56,18 @@ export default function (moviesRepository) {
         res.status(201).json({
           data: serializeMovie(movie)
         });
-      });
+      })
+      .catch(next);
   }
 
-  function update (req, res) {
+  function update (req, res, next) {
     let model, patchModel;
 
     try {
       model = deserializeMovieRequest(req);
       if (!model.id) {
         res.status(400).sendError(new Error('Must specify an "id" property value to use.'));
+        return;
       }
     }
     catch (err) {
@@ -85,10 +90,11 @@ export default function (moviesRepository) {
         res.json({
           data: serializeMovie(movie)
         });
-      });
+      })
+      .catch(next);
   }
 
-  function remove (req, res) {
+  function remove (req, res, next) {
     moviesRepository.delete(req.params.id)
       .then((movie) => {
         if (!movie) {
@@ -96,7 +102,8 @@ export default function (moviesRepository) {
           return;
         }
         res.status(204).send();
-      });
+      })
+      .catch(next);
   }
 };
 

--- a/app/src/MovieBrowser/DetailPage/MovieDetail/index.js
+++ b/app/src/MovieBrowser/DetailPage/MovieDetail/index.js
@@ -1,10 +1,12 @@
 import { Link } from 'react-router-dom';
 
+import { isSafeHttpUrl } from '../../../utils/url.js';
 import './movie-detail.css';
 
 function MovieDetail({ movie, deleteMovieCallback }) {
   const altText = `Poster for ${movie.title}`;
-  const image = movie.imageUrl ? (<img src={movie.imageUrl} alt={altText}/>) : '';
+  const safeUrl = isSafeHttpUrl(movie.imageUrl) ? movie.imageUrl : null;
+  const image = safeUrl ? (<img src={safeUrl} alt={altText}/>) : '';
 
   return (
     <div className="movie-detail">

--- a/app/src/MovieBrowser/MovieForm/index.js
+++ b/app/src/MovieBrowser/MovieForm/index.js
@@ -1,5 +1,7 @@
 import { useState } from "react";
 
+import { isSafeHttpUrl } from '../../utils/url.js';
+
 function MovieForm ({ movie, submitFormCallback }) {
   const initialMovie = movie || {
     title: '',
@@ -8,6 +10,7 @@ function MovieForm ({ movie, submitFormCallback }) {
     imageUrl: ''
   };
   const [localMovie, setLocalMovie] = useState(initialMovie);
+  const [urlError, setUrlError] = useState('');
 
   return (
     <form onSubmit={submitForm}>
@@ -36,6 +39,9 @@ function MovieForm ({ movie, submitFormCallback }) {
         id="movie-rating"
         name="rating"
         type="number"
+        min="0"
+        max="10"
+        step="0.1"
         value={localMovie && localMovie.rating}
         onChange={updateMovieField}
       />
@@ -44,10 +50,11 @@ function MovieForm ({ movie, submitFormCallback }) {
       <input
         id="movie-image-url"
         name="imageUrl"
-        type="text"
+        type="url"
         value={localMovie && localMovie.imageUrl}
         onChange={updateMovieField}
       />
+      {urlError && <p role="alert" style={{ color: 'red' }}>{urlError}</p>}
 
       <div>
         <input type="submit" value="Submit" />
@@ -59,6 +66,10 @@ function MovieForm ({ movie, submitFormCallback }) {
     const target = event.target;
     const name = target.name;
     const value = target.type === 'number' ? Number(target.value) : target.value;
+
+    if (name === 'imageUrl') {
+      setUrlError('');
+    }
 
     setLocalMovie({
       ...localMovie,
@@ -73,7 +84,12 @@ function MovieForm ({ movie, submitFormCallback }) {
     if (!movie.id) {
       delete movie.id;
     }
-    if (movie.imageUrl.trim() === '') {
+    if (movie.imageUrl && movie.imageUrl.trim() !== '') {
+      if (!isSafeHttpUrl(movie.imageUrl)) {
+        setUrlError('Image URL must start with http:// or https://');
+        return;
+      }
+    } else {
       movie.imageUrl = null;
     }
     submitFormCallback(movie);

--- a/app/src/MovieBrowser/MovieGrid/MovieCard/index.js
+++ b/app/src/MovieBrowser/MovieGrid/MovieCard/index.js
@@ -1,10 +1,12 @@
 import { Link } from 'react-router-dom';
 
+import { isSafeHttpUrl } from '../../../utils/url.js';
 import './movie-card.css';
 
 function MovieCard ({ movie }) {
   const altText = `Poster for ${movie.title}`;
-  const image = movie.imageUrl ? (<img src={movie.imageUrl} alt={altText} className="movie-card__image" />) : '';
+  const safeUrl = isSafeHttpUrl(movie.imageUrl) ? movie.imageUrl : null;
+  const image = safeUrl ? (<img src={safeUrl} alt={altText} className="movie-card__image" />) : '';
 
   return (
     <li className="movie-card">

--- a/app/src/utils/url.js
+++ b/app/src/utils/url.js
@@ -1,0 +1,9 @@
+export function isSafeHttpUrl(url) {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Two separate commits address security vulnerabilities found across the backend API and frontend React app.

---

### Backend API (`api/`) — commit `73d3b1a`

| Vulnerability | Fix |
|---|---|
| Deprecated `findByIdAndRemove()` (breaks in future Mongoose) | Replaced with `findByIdAndDelete()` |
| Unhandled promise rejections in all route handlers — DB errors crash the server | Added `next` param and `.catch(next)` to every handler so errors flow to the Express error handler |
| Missing `return` after early 403/400 responses in `create`/`update` — could send headers twice | Added `return` after each early response |
| No request body size limit — DoS via oversized payloads | Set `limit: '100kb'` on `bodyParser.json()` |
| No input validation on movie attributes — allowed arbitrary types, out-of-range values, and `javascript:`/`data:` URIs stored in `imageUrl` | Added per-attribute validators in `resource.deserializer.js`: type checks, string length caps (title ≤ 500, imageUrl ≤ 2048), year range (1888–2200), rating range (0–10), and http/https-only protocol enforcement on imageUrl |

---

### Frontend App (`app/`) — commit `e886d47`

| Vulnerability | Fix |
|---|---|
| `imageUrl` rendered directly into `<img src>` — stored `javascript:` or `data:` URIs could execute in some browsers/contexts | Added `isSafeHttpUrl()` utility (`app/src/utils/url.js`) that validates protocol via `URL` constructor; `MovieCard` and `MovieDetail` now silently drop any URL that is not `http:` or `https:` |
| No client-side URL validation — malformed or malicious URLs could be submitted | Changed imageUrl field to `type="url"` for browser-native validation; added explicit protocol check on submit with an accessible error message (`role="alert"`) |
| No constraints on rating input | Added `min="0"`, `max="10"`, and `step="0.1"` to the rating field |

## Test plan

- [ ] POST a movie with `"imageUrl": "javascript:alert(1)"` → expect 400 from API
- [ ] POST a movie with `"imageUrl": "data:text/html,<h1>x</h1>"` → expect 400 from API
- [ ] POST a movie with `"rating": 99` → expect 400 from API
- [ ] POST a movie with `"releaseYear": "not-a-year"` → expect 400 from API
- [ ] POST a movie with a valid payload → expect 201
- [ ] Submit the Add Movie form with a `javascript:` image URL → expect inline error, no submission
- [ ] Submit the Add Movie form with a valid `https://` image URL → expect success
- [ ] Verify movie cards and detail pages render images normally for valid URLs
- [ ] Verify no image is shown when a stored URL uses a non-http/https scheme

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0188kABbkfRUDLP2sGWJqevz)_